### PR TITLE
[CM-8195] now logs error if trying to log to a non llm project (#67)

### DIFF
--- a/src/comet_llm/backend_error_codes.py
+++ b/src/comet_llm/backend_error_codes.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# *******************************************************
+#   ____                     _               _
+#  / ___|___  _ __ ___   ___| |_   _ __ ___ | |
+# | |   / _ \| '_ ` _ \ / _ \ __| | '_ ` _ \| |
+# | |__| (_) | | | | | |  __/ |_ _| | | | | | |
+#  \____\___/|_| |_| |_|\___|\__(_)_| |_| |_|_|
+#
+#  Sign up for free at https://www.comet.com
+#  Copyright (C) 2015-2023 Comet ML INC
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this package.
+# *******************************************************
+
+UNABLE_TO_LOG_TO_NON_LLM_PROJECT = 34323

--- a/src/comet_llm/experiment_api/request_exception_wrapper.py
+++ b/src/comet_llm/experiment_api/request_exception_wrapper.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, List
 import requests  # type: ignore
 
 from .. import config, exceptions
+from ..handlers import failed_response
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +43,8 @@ def wrap(check_on_prem: bool = False) -> Callable:
                             f"{comet_url}. Check that your Comet "
                             f"installation is up-to-date and check the traceback for more details."
                         )
+                if exception.response is not None:
+                    exception_args.append(failed_response.handle(exception.response))
 
                 _debug_log(exception)
 

--- a/src/comet_llm/handlers/failed_response.py
+++ b/src/comet_llm/handlers/failed_response.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# *******************************************************
+#   ____                     _               _
+#  / ___|___  _ __ ___   ___| |_   _ __ ___ | |
+# | |   / _ \| '_ ` _ \ / _ \ __| | '_ ` _ \| |
+# | |__| (_) | | | | | |  __/ |_ _| | | | | | |
+#  \____\___/|_| |_| |_|\___|\__(_)_| |_| |_|_|
+#
+#  Sign up for free at https://www.comet.com
+#  Copyright (C) 2015-2023 Comet ML INC
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this package.
+# *******************************************************
+import json
+from typing import Optional
+
+import requests  # type: ignore
+
+from .. import backend_error_codes, logging_messages
+
+SDK_ERROR_CODES_LOGGING_MESSAGE = {
+    backend_error_codes.UNABLE_TO_LOG_TO_NON_LLM_PROJECT: logging_messages.UNABLE_TO_LOG_TO_NON_LLM_PROJECT
+}
+
+
+def handle(response: requests.Response) -> Optional[str]:
+    sdk_error_code = json.loads(response.text)["sdk_error_code"]
+    return SDK_ERROR_CODES_LOGGING_MESSAGE.get(sdk_error_code)

--- a/src/comet_llm/logging_messages.py
+++ b/src/comet_llm/logging_messages.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# *******************************************************
+#   ____                     _               _
+#  / ___|___  _ __ ___   ___| |_   _ __ ___ | |
+# | |   / _ \| '_ ` _ \ / _ \ __| | '_ ` _ \| |
+# | |__| (_) | | | | | |  __/ |_ _| | | | | | |
+#  \____\___/|_| |_| |_|\___|\__(_)_| |_| |_|_|
+#
+#  Sign up for free at https://www.comet.com
+#  Copyright (C) 2015-2023 Comet ML INC
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this package.
+# *******************************************************
+
+
+UNABLE_TO_LOG_TO_NON_LLM_PROJECT = "Failed to send prompt to the specified project as it is not an LLM project, please specify a different project name."


### PR DESCRIPTION
* now logs error if trying to log to a non llm project

* fixed lint errors

* added an abstract function for handling responses

* added safe mechanism

* fixed lint

* fixes

* fixed lint

* lint